### PR TITLE
raise UnsupportedPlatform error

### DIFF
--- a/luma/lcd/aux.py
+++ b/luma/lcd/aux.py
@@ -3,6 +3,12 @@
 # See LICENSE.rst for details.
 
 
+import luma.core.error
+
+
+__all__ = ["backlight"]
+
+
 class backlight(object):
     """
     Controls a backlight, assumed to be on GPIO 18 (PWM_CLK0) by default.
@@ -10,6 +16,7 @@ class backlight(object):
     :param gpio: GPIO interface (must be compatible with `RPi.GPIO <https://pypi.python.org/pypi/RPi.GPIO>`_).
     :param bcm_LIGHT: the GPIO pin to use for the backlight.
     :type bcm_LIGHT: int
+    :raises luma.core.error.UnsupportedPlatform: GPIO access not available.
     """
     def __init__(self, gpio=None, bcm_LIGHT=18):
         self._bcm_LIGHT = bcm_LIGHT
@@ -33,5 +40,10 @@ class backlight(object):
         # RPi.GPIO _really_ doesn't like being run on anything other than
         # a Raspberry Pi... this is imported here so we can swap out the
         # implementation for a mock
-        import RPi.GPIO
-        return RPi.GPIO
+        try:
+            import RPi.GPIO
+            return RPi.GPIO
+        except RuntimeError as e:
+            if str(e) == 'This module can only be run on a Raspberry Pi!':
+                raise luma.core.error.UnsupportedPlatform(
+                    'GPIO access not available')

--- a/luma/lcd/aux.py
+++ b/luma/lcd/aux.py
@@ -3,12 +3,13 @@
 # See LICENSE.rst for details.
 
 
-import luma.core.error
+from luma.core import lib
 
 
 __all__ = ["backlight"]
 
 
+@lib.rpi_gpio
 class backlight(object):
     """
     Controls a backlight, assumed to be on GPIO 18 (PWM_CLK0) by default.
@@ -35,15 +36,3 @@ class backlight(object):
         assert(value in [True, False])
         self._gpio.output(self._bcm_LIGHT,
                           self._gpio.LOW if value else self._gpio.HIGH)
-
-    def __rpi_gpio__(self):
-        # RPi.GPIO _really_ doesn't like being run on anything other than
-        # a Raspberry Pi... this is imported here so we can swap out the
-        # implementation for a mock
-        try:
-            import RPi.GPIO
-            return RPi.GPIO
-        except RuntimeError as e:
-            if str(e) == 'This module can only be run on a Raspberry Pi!':
-                raise luma.core.error.UnsupportedPlatform(
-                    'GPIO access not available')

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     namespace_packages=["luma"],
     packages=["luma.lcd"],
     zip_safe=False,
-    install_requires=["luma.core"],
+    install_requires=["luma.core>=0.5.2"],
     setup_requires=pytest_runner,
     tests_require=test_deps,
     extras_require={

--- a/tests/test_backlight.py
+++ b/tests/test_backlight.py
@@ -8,7 +8,11 @@ try:
 except ImportError:
     from mock import Mock
 
+import pytest
+
+import luma.core.error
 from luma.lcd.aux import backlight
+
 
 gpio = Mock(unsafe=True)
 
@@ -19,6 +23,12 @@ def setup_function(function):
     gpio.OUT = 2
     gpio.HIGH = 3
     gpio.LOW = 4
+
+
+def test_unsupported_platform():
+    with pytest.raises(luma.core.error.UnsupportedPlatform) as ex:
+        backlight(bcm_LIGHT=19)
+    assert str(ex.value) == 'GPIO access not available'
 
 
 def test_init():


### PR DESCRIPTION
Raise `luma.core.error.UnsupportedPlatform` when GPIO access is not available.