### PR TITLE
Add a PWM backlight Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ target/
 .project
 .pydevproject
 .settings/
+
+# virtualenv
+.venv
+venv/
+ENV/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,3 +21,4 @@ Contributors
 * Saumyakanta Sahoo (@somu1795)
 * Philip Howard (@Gadgetoid)
 * Ricardo Amendoeira (@ric2b)
+* Kevin Stone (@kevinastone)

--- a/luma/lcd/device.py
+++ b/luma/lcd/device.py
@@ -86,6 +86,44 @@ class GPIOBacklight:
         self._gpio.output(self._pin, self._enabled if is_enabled else self._disabled)
 
 
+class PWMBacklight:
+    """
+    Helper class for controlling the LCD backlight using a PWM channel pin.
+
+    :param gpio: GPIO interface (must be compatible with `RPi.GPIO <https://pypi.python.org/pypi/RPi.GPIO>`_).
+    :param pin: the GPIO pin to use for the backlight.
+    :type pin: int
+    :param frequency: The frequency to use for the PWM channel.
+    :type frequency: float
+    :raises luma.core.error.UnsupportedPlatform: GPIO access not available.
+
+    .. versionadded:: 2.3.0
+    """
+    def __init__(self, gpio, pin=18, frequency=362):
+        self._gpio = gpio
+
+        try:
+            self._pwm = self._gpio.PWM(pin, frequency)
+            self._pwm.start(0.0)
+        except RuntimeError as e:
+            if str(e) == 'Module not imported correctly!':
+                raise luma.core.error.UnsupportedPlatform('GPIO access not available')
+
+    def __call__(self, value):
+        """
+        Set the LCD Backlight
+
+        :param value: Sets the value of the backlight.  Can provide a bool
+        (True/False) to turn on/off or a float to set the backlight intensity in
+        percentage (0 <= value <= 100.0).
+        :type value: bool or float
+        """
+        if value in (True, False):
+            value = 100.0 if value else 0.0
+        assert 0.0 <= value <= 100.0
+        self._pwm.ChangeDutyCycle(value)
+
+
 @rpi_gpio
 class backlit_device(device):
     """
@@ -96,15 +134,20 @@ class backlit_device(device):
     :type gpio_LIGHT: int
     :param active_low: Set to true if active low (default), false otherwise.
     :type active_low: bool
+    :param pwm_frequency: Use PWM for backlight brightness control with the specified frequency when provided.
+    :type pwm_frequency: float
     :raises luma.core.error.UnsupportedPlatform: GPIO access not available.
 
     .. versionadded:: 2.0.0
     """
-    def __init__(self, const=None, serial_interface=None, gpio=None, gpio_LIGHT=18, active_low=True, **kwargs):
+    def __init__(self, const=None, serial_interface=None, gpio=None, gpio_LIGHT=18, active_low=True, pwm_frequency=None, **kwargs):
         super(backlit_device, self).__init__(const, serial_interface)
 
         gpio = gpio or self.__rpi_gpio__()
-        self.backlight = GPIOBacklight(gpio, pin=gpio_LIGHT, active_low=active_low)
+        if pwm_frequency:
+            self.backlight = PWMBacklight(gpio, pin=gpio_LIGHT, frequency=pwm_frequency)
+        else:
+            self.backlight = GPIOBacklight(gpio, pin=gpio_LIGHT, active_low=active_low)
 
         self.persist = True
         self.backlight(True)

--- a/luma/lcd/device.py
+++ b/luma/lcd/device.py
@@ -46,13 +46,53 @@ from luma.lcd.segment_mapper import dot_muncher
 __all__ = ["pcd8544", "st7735", "ht1621", "uc1701x", "st7567", "ili9341"]
 
 
+class GPIOBacklight:
+    """
+    Helper class for controlling the LCD backlight using a digital GPIO output pin.
+
+    :param gpio: GPIO interface (must be compatible with `RPi.GPIO <https://pypi.python.org/pypi/RPi.GPIO>`_).
+    :param pin: the GPIO pin to use for the backlight.
+    :type pin: int
+    :param active_low: Set to True if active low (default), False otherwise.
+    :type active_low: bool
+    :raises luma.core.error.UnsupportedPlatform: GPIO access not available.
+
+    .. versionadded:: 2.3.0
+    """
+    def __init__(self, gpio, pin=18, active_low=True):
+        self._gpio = gpio
+        self._pin = pin
+        if active_low:
+            self._enabled = self._gpio.LOW
+            self._disabled = self._gpio.HIGH
+        else:
+            self._enabled = self._gpio.HIGH
+            self._disabled = self._gpio.LOW
+
+        try:
+            self._gpio.setup(self._pin, self._gpio.OUT)
+        except RuntimeError as e:
+            if str(e) == 'Module not imported correctly!':
+                raise luma.core.error.UnsupportedPlatform('GPIO access not available')
+
+    def __call__(self, is_enabled):
+        """
+        Toggle the LCD Backlight
+
+        :param is_enabled: Turn on or off the backlight.
+        :type is_enabled: bool
+        """
+        assert is_enabled in (True, False)
+        self._gpio.output(self._pin, self._enabled if is_enabled else self._disabled)
+
+
 @rpi_gpio
 class backlit_device(device):
     """
     Controls a backlight (active low), assumed to be on GPIO 18 (``PWM_CLK0``) by default.
 
     :param gpio: GPIO interface (must be compatible with `RPi.GPIO <https://pypi.python.org/pypi/RPi.GPIO>`_).
-    :param gpio_LIGHT: the GPIO pin to use for the backlight.
+    :param gpio_LIGHT: The GPIO pin to use for the backlight.
     :type gpio_LIGHT: int
     :param active_low: Set to true if active low (default), false otherwise.
     :type active_low: bool
@@ -63,34 +103,11 @@ class backlit_device(device):
     def __init__(self, const=None, serial_interface=None, gpio=None, gpio_LIGHT=18, active_low=True, **kwargs):
         super(backlit_device, self).__init__(const, serial_interface)
 
-        self._gpio_LIGHT = gpio_LIGHT
-        self._gpio = gpio or self.__rpi_gpio__()
-        if active_low:
-            self._enabled = self._gpio.LOW
-            self._disabled = self._gpio.HIGH
-        else:
-            self._enabled = self._gpio.HIGH
-            self._disabled = self._gpio.LOW
-
-        try:
-            self._gpio.setup(self._gpio_LIGHT, self._gpio.OUT)
-        except RuntimeError as e:
-            if str(e) == 'Module not imported correctly!':
-                raise luma.core.error.UnsupportedPlatform('GPIO access not available')
+        gpio = gpio or self.__rpi_gpio__()
+        self.backlight = GPIOBacklight(gpio, pin=gpio_LIGHT, active_low=active_low)
 
         self.persist = True
         self.backlight(True)
-
-    def backlight(self, value):
-        """
-        Switches on the backlight on and off.
-
-        :param value: Switched on when ``True`` supplied, else ``False`` switches it off.
-        :type value: bool
-        """
-        assert(value in [True, False])
-        self._gpio.output(self._gpio_LIGHT,
-                          self._enabled if value else self._disabled)
 
     def cleanup(self):
         """


### PR DESCRIPTION
Allows a substitute PWM based backlight control in place of the digital GPIO control.

The existing `RPi.GPIO` doesn't support hardware PWM, so this isn't currently a strong solution without better support for alternative GPIO libraries such as `pigpio`.  I'd recommend transitioning this library to `gpiozero` which provides better abstractions over the different GPIO libraries on the RasPi.

This is a follow-up to #95.