### PR TITLE
New diff-to-previous framebuffer implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ addons:
         packages:
             - graphviz
 
-install: pip install --ignore-installed --upgrade setuptools pip tox coveralls
+install:
+  - pip cache purge 
+  - pip install --ignore-installed --upgrade setuptools pip tox coveralls
 script: tox -vv
 after_success: if [ "$TOXENV" == "py38" ]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ addons:
         packages:
             - graphviz
 
-install:
-  - pip cache purge 
-  - pip install --ignore-installed --upgrade setuptools pip tox coveralls
+install: pip install --ignore-installed --upgrade setuptools pip tox coveralls
 script: tox -vv
 after_success: if [ "$TOXENV" == "py38" ]; then coveralls; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ ChangeLog
 +------------+---------------------------------------------------------------------+------------+
 | Version    | Description                                                         | Date       |
 +============+=====================================================================+============+
+| *TBC*      | * Improved performance for ST7739 and ILI9341 displays              |            |
++------------+---------------------------------------------------------------------+------------+
 | **2.6.0**  | * Drop support for Python 3.5, only 3.6 or newer is supported now   | 2020/10/25 |
 |            | * Pin luma.core to 1.x.y line only, in anticipation of performance  |            |
 |            |   improvements in upcoming major release                            |            |

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,7 @@ setup(
     namespace_packages=["luma"],
     packages=find_packages(),
     zip_safe=False,
-    # TODO: Replace with >=2.0.0 once package has been released to PyPi
-    install_requires=["luma.core @ https://github.com/rm-hull/luma.core/tarball/feature/improved-framebuffer-performance#egg=luma.core"],
+    install_requires=["luma.core>=2.0.0"],
     setup_requires=pytest_runner,
     tests_require=test_deps,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
     namespace_packages=["luma"],
     packages=find_packages(),
     zip_safe=False,
-    install_requires=["luma.core>=1.16.2,<2.0.0"],
+    # TODO: Replace with >=2.0.0 once package has been released to PyPi
+    install_requires=["luma.core @ https://github.com/rm-hull/luma.core/tarball/feature/improved-framebuffer-performance#egg=luma.core"],
     setup_requires=pytest_runner,
     tests_require=test_deps,
     extras_require={

--- a/tests/test_ili9341.py
+++ b/tests/test_ili9341.py
@@ -11,6 +11,7 @@ import pytest
 
 from luma.lcd.device import ili9341
 from luma.core.render import canvas
+from luma.core.framebuffer import full_frame
 
 from baseline_data import get_reference_data, primitives
 from helpers import serial, setup_function, assert_invalid_dimensions  # noqa: F401
@@ -29,7 +30,7 @@ def test_init_320x240():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    ili9341(serial, gpio=Mock())
+    ili9341(serial, gpio=Mock(), framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -75,7 +76,7 @@ def test_init_240x240():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    ili9341(serial, gpio=Mock(), width=240, height=240)
+    ili9341(serial, gpio=Mock(), width=240, height=240, framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -121,7 +122,7 @@ def test_init_320x180():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    ili9341(serial, gpio=Mock(), width=320, height=180)
+    ili9341(serial, gpio=Mock(), width=320, height=180, framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -175,7 +176,7 @@ def test_offsets():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    ili9341(serial, gpio=Mock(), width=240, height=240, h_offset=2, v_offset=1)
+    ili9341(serial, gpio=Mock(), width=240, height=240, h_offset=2, v_offset=1, framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -230,8 +231,8 @@ def test_show():
     serial.command.assert_called_once_with(41)
 
 
-def test_display():
-    device = ili9341(serial, gpio=Mock())
+def test_display_full_frame():
+    device = ili9341(serial, gpio=Mock(), framebuffer=full_frame())
     serial.reset_mock()
 
     recordings = []

--- a/tests/test_st7735.py
+++ b/tests/test_st7735.py
@@ -11,6 +11,7 @@ import pytest
 
 from luma.lcd.device import st7735
 from luma.core.render import canvas
+from luma.core.framebuffer import full_frame
 
 from baseline_data import get_reference_data, primitives
 from helpers import serial, setup_function, assert_invalid_dimensions  # noqa: F401
@@ -29,7 +30,7 @@ def test_init_160x128():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    st7735(serial, gpio=Mock())
+    st7735(serial, gpio=Mock(), framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -72,7 +73,7 @@ def test_init_128x128():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    st7735(serial, gpio=Mock(), width=128, height=128)
+    st7735(serial, gpio=Mock(), width=128, height=128, framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -115,7 +116,7 @@ def test_init_160x80():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    st7735(serial, gpio=Mock(), width=160, height=80)
+    st7735(serial, gpio=Mock(), width=160, height=80, framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -166,7 +167,7 @@ def test_offsets():
     serial.command.side_effect = command
     serial.data.side_effect = data
 
-    st7735(serial, gpio=Mock(), width=128, height=128, h_offset=2, v_offset=1)
+    st7735(serial, gpio=Mock(), width=128, height=128, h_offset=2, v_offset=1, framebuffer=full_frame())
 
     assert serial.data.called
     assert serial.command.called
@@ -219,7 +220,7 @@ def test_show():
 
 
 def test_display():
-    device = st7735(serial, gpio=Mock())
+    device = st7735(serial, gpio=Mock(), framebuffer=full_frame())
     serial.reset_mock()
 
     recordings = []


### PR DESCRIPTION
### Implementation status
🟢 ST7735 
🟢 HD44780
🟢 ILI9341  

### Notes
For reference **bounce.py** demo on ILI9341 (SPI bus speed @ 32MHz) run at approx 10 FPS on RPI B4 using the current implementation. For the new implementation, **bounce.py** is reporting the following FPS for the following segment size:

 | `num_segments` | FPS |
|--------------|-----|
| 100          | 60  |
| 64           | 70  |
| 25           | 86  |
| 16           | 75  |
| 4            | 24  |
| 1            | 10  |

Obviously a segment size of 1 - this is equivalent to the current implementation, but for the others WOW! ... I didn't expect such a huge improvement. The best value for `num_segments` will largely depend on what the application draws on the screen, but for the bounce demo, having 25 segments appeared to be the sweet spot for maximal frame rate.
