### PR TITLE
Update hardware.rst

### DIFF
--- a/doc/hardware.rst
+++ b/doc/hardware.rst
@@ -277,7 +277,10 @@ Device Pin Name   Remarks          RPi Pin  RPi Function
 
 Suggested Wiring
 ----------------
-
+.. note::
+   * The default GPIO for backlight is GPIO 18. This pin is also used for PCM_CLK in I2S. So
+     when you use the I2S please specifying the new BCM pin number with the ``gpio_LIGHT`` argument. 
+     
 PCD8544
 ~~~~~~~
 
@@ -329,7 +332,7 @@ RESET or RST  Reset             P01-18   GPIO 24
 DC            Data/command      P01-16   GPIO 23
 SDI(MOSI)     SPI data          P01-19   GPIO 10 (MOSI)
 SCK or CLK    SPI clock         P01-23   GPIO 11 (SCLK)
-LED           Backlight control P01-12   GPIO 18
+LED           Backlight control P01-12   GPIO 18 (PCM_CLK)
 ============= ================= ======== ==============
 
 ST7567

--- a/luma/lcd/device.py
+++ b/luma/lcd/device.py
@@ -669,6 +669,7 @@ class ili9341(backlit_device, __framebuffer_mixin):
                      0x00, 0x0e, 0x14, 0x03, 0x11, 0x07, 0x31, 0xc1,
                      0x48, 0x08, 0x0f, 0x0c, 0x31, 0x36, 0x0f)
         self.command(0x11)                                # Sleep out
+        sleep(0.12)
         self.clear()
         self.show()
 


### PR DESCRIPTION
Add note that default ``gpio_LIGHT`` causes problems with I2S.

#145 