### PR TITLE
doc: add width/height in hd44780 usage examples

### DIFF
--- a/doc/HD44780.rst
+++ b/doc/HD44780.rst
@@ -47,7 +47,7 @@ the display is to use the `text` property which operates similarly to the
   from luma.lcd.device import hd44780
 
   interface = bitbang_6800(RS=7, E=8, PINS=[25, 24, 23, 27])
-  device = hd44780(interface)
+  device = hd44780(interface, width=16, height=2)
 
   device.text = 'Hello World'
 
@@ -116,7 +116,7 @@ Here is a small example of how this can be leveraged.
   from PIL import Image, ImageDraw
 
   interface = bitbang_6800(RS=7, E=8, PINS=[25, 24, 23, 27])
-  device = hd44780(interface)
+  device = hd44780(interface, width=16, height=2)
 
   def progress_bar(width, height, percentage):
     img = Image.new('1', (width, height))


### PR DESCRIPTION
so people don't have to look at the api docs for those 2 most commonly used params.