### PR TITLE
Add width and height parameters to ST7789 device

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,3 +25,4 @@ Contributors
 * Dhrone (@dhrone)
 * Matthew Lovell (@mattblovell)
 * Maciej Sokolowski (@matemaciek)
+* Frederic Meeuwissen (@Frederic98)

--- a/luma/lcd/device.py
+++ b/luma/lcd/device.py
@@ -330,7 +330,8 @@ class st7789(backlit_device):
         """Send a command to the display, with optional arguments.
            The arguments are sent as data bytes, in accordance with the ST7789 datasheet."""
         super(st7789, self).command(cmd)
-        self.data(args)
+        if args:
+            self.data(args)
 
     def set_window(self, x1, y1, x2, y2):
         self.command(0x2A,            # CASET (2Ah): Column Address Set

--- a/luma/lcd/device.py
+++ b/luma/lcd/device.py
@@ -298,9 +298,9 @@ class st7789(backlit_device):
 
     .. versionadded:: 2.9.0
     """
-    def __init__(self, serial_interface=None, rotate=0, **kwargs):
+    def __init__(self, serial_interface=None, width=240, height=240, rotate=0, **kwargs):
         super(st7789, self).__init__(luma.lcd.const.st7789, serial_interface, **kwargs)
-        self.capabilities(240, 240, rotate, mode="RGB")
+        self.capabilities(width, height, rotate, mode="RGB")
 
         self.command(0x36, 0x70)     # MADCTL (36h): Memory Data Access Control: Bottom to Top, Right to Left, Reverse Mode
         self.command(0x3A, 0x06)     # COLMOD (3Ah): Interface Pixel Format: 18bit/pixel
@@ -326,6 +326,12 @@ class st7789(backlit_device):
         self.clear()
         self.show()
 
+    def command(self, cmd, *args):
+        """Send a command to the display, with optional arguments.
+           The arguments are sent as data bytes, in accordance with the ST7789 datasheet."""
+        super(st7789, self).command(cmd)
+        self.data(args)
+
     def set_window(self, x1, y1, x2, y2):
         self.command(0x2A,            # CASET (2Ah): Column Address Set
                      x1 >> 8, x1 & 0xFF, (x2 - 1) >> 8, (x2 - 1) & 0xFF)
@@ -334,8 +340,7 @@ class st7789(backlit_device):
         self.command(0x2C)            # RAMWR (2Ch): Memory Write
 
     def display(self, image):
-        w, h = 240, 240
-        self.set_window(0, 0, w, h)
+        self.set_window(0, 0, self._w, self._h)
 
         image = self.preprocess(image)
         self.data(list(image.convert("RGB").tobytes()))


### PR DESCRIPTION
This pull request adds support for more ST7789 based screens with resolutions other than 240x240.

As in #142, passing the width and height to set_window() didn't directly work. This is because the arguments to the RASET and CASET commands are sent as command bytes. They should, however, be sent as data bytes. This also applies to all other commands with arguments, like those called to initialize the screen.  
The reason that the screen went blank in #142 was because 320px translates to 0x01 0x3F, where the command 0x01 is mapped to software reset in the LCD driver.

To solve this, I add the `command(self, cmd, *args)` function in st7789 where it calls `super.command(self, cmd)` and `self.data(args)` to send the arguments as data bytes.